### PR TITLE
Fix duplicate answers being treated as correct

### DIFF
--- a/logic.go
+++ b/logic.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"math/rand"
-	"slices"
-	"time"
+        "encoding/json"
+        "errors"
+        "math/rand"
+        "time"
 
-	"gorm.io/gorm"
+        "gorm.io/gorm"
 )
 
 func drawQuestions(allIDs []string, count int, seed *int64) []string {
@@ -26,14 +25,24 @@ func drawQuestions(allIDs []string, count int, seed *int64) []string {
 }
 
 func isCorrectAllOrNothing(selected, correct []string) bool {
-	if len(selected) != len(correct) { return false }
-	for _, k := range selected {
-		if !slices.Contains(correct, k) {
-			return false
-		}
-	}
-	// sprawdzone też równoliczne
-	return true
+        if len(selected) != len(correct) {
+                return false
+        }
+        // treat both inputs as sets to avoid accepting duplicates in `selected`
+        selSet := make(map[string]struct{}, len(selected))
+        for _, k := range selected {
+                selSet[k] = struct{}{}
+        }
+        // if there were duplicates in `selected`, the set will be smaller
+        if len(selSet) != len(correct) {
+                return false
+        }
+        for _, k := range correct {
+                if _, ok := selSet[k]; !ok {
+                        return false
+                }
+        }
+        return true
 }
 
 func computeExamScore(db *gorm.DB, examID string) (float64, int, int, error) {

--- a/logic_test.go
+++ b/logic_test.go
@@ -1,0 +1,45 @@
+package main
+
+import "testing"
+
+func TestIsCorrectAllOrNothing(t *testing.T) {
+    tests := []struct {
+        name     string
+        selected []string
+        correct  []string
+        want     bool
+    }{
+        {
+            name:     "exact match",
+            selected: []string{"a", "b"},
+            correct:  []string{"a", "b"},
+            want:     true,
+        },
+        {
+            name:     "missing option",
+            selected: []string{"a"},
+            correct:  []string{"a", "b"},
+            want:     false,
+        },
+        {
+            name:     "extra option",
+            selected: []string{"a", "b", "c"},
+            correct:  []string{"a", "b"},
+            want:     false,
+        },
+        {
+            name:     "duplicate option",
+            selected: []string{"a", "a"},
+            correct:  []string{"a", "b"},
+            want:     false,
+        },
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            if got := isCorrectAllOrNothing(tt.selected, tt.correct); got != tt.want {
+                t.Errorf("isCorrectAllOrNothing() = %v, want %v", got, tt.want)
+            }
+        })
+    }
+}
+


### PR DESCRIPTION
## Summary
- Prevent `isCorrectAllOrNothing` from accepting duplicate selected answers
- Add unit tests for answer correctness helper

## Testing
- `go test ./... -run Test -v`


------
https://chatgpt.com/codex/tasks/task_e_68976a6f56a08333a94ac62627a173c6